### PR TITLE
add table with assignments and github Ids to Readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,14 +13,14 @@ Deployments:
 
 TODO: Fill in this table with correct information. 
 
-| Table                     | Name         | Github Id |
-|---------------------------|--------------|-----------|
-| UCSBDiningCommonsMenuItem |              |           |
-| UCSBOrganization          |              |           |
-| RecommendationRequest     |              |           |
-| MenuItemReview            |              |           |
-| HelpRequest               |              |           |
-| Articles                  |              |           |
+| Table                     | Name       | Github Id     |
+| ------------------------- | ---------- | ------------- |
+| UCSBDiningCommonsMenuItem | Rohan N.   | rohannihalani |
+| UCSBOrganization          | Pranav G.  | pgunhal       |
+| RecommendationRequest     | Arya S.    | AryaSadeghi21 |
+| MenuItemReview            | Joaquin W. | Joaquin-Wong  |
+| HelpRequest               | Safwan R.  | safwanmrahman |
+| Articles                  | Nick K.    | nickkamenica  |
 
 Remember though, that in spite of these initial  assignments, it is still
 a team project.  Please help other team members to finish their work


### PR DESCRIPTION
## What changed
The README.md has a table at the top like the one shown below
indicating which team member is initially taking on
which database table, and which is unassigned.

Closes Issue #55 

## Testing
Open readme.md and the table will show up with team member names and github ids. 

