### PR TITLE
Create Form Component for UCSBOrganization + testing

### DIFF
--- a/frontend/src/fixtures/organizationFixtures.js
+++ b/frontend/src/fixtures/organizationFixtures.js
@@ -1,32 +1,33 @@
 const organizationFixtures = {
   oneOrganization: [
     {
-      id: 1,
-      name: "SB Hacks",
-      description: "Student run Hackathon at UCSB",
+      orgCode: "SBHACKS",
+      orgTranslationShort: "SB Hacks",
+      orgTranslation: "Student-run Hackathon at UCSB",
+      inactive: false,
     },
   ],
 
-  threeRestaurants: [
+  threeOrganizations: [
     {
-      id: 2,
-      name: "ACM",
-      description:
-        "The main CS club at UCSB.  They have a lot of fun events and are a great way to meet other CS students",
+      orgCode: "ACM",
+      orgTranslationShort: "ACM",
+      orgTranslation: "Association for Computing Machinery",
+      inactive: false,
     },
 
     {
-      id: 3,
-      name: "Data Science Club",
-      description:
-        "A club for students interested in data science.  They have workshops and projects related to data science and machine learning",
+      orgCode: "DSC",
+      orgTranslationShort: "Data Science Club",
+      orgTranslation: "Data Science Club at UCSB",
+      inactive: false,
     },
 
     {
-      id: 4,
-      name: "UCSB Sports Analytics Club",
-      description:
-        "A club for students interested in sports analytics.  They have workshops and projects related to sports analytics and machine learning",
+      orgCode: "SAC",
+      orgTranslationShort: "Sports Analytics Club",
+      orgTranslation: "UCSB Sports Analytics Club",
+      inactive: true,
     },
   ],
 };

--- a/frontend/src/fixtures/organizationFixtures.js
+++ b/frontend/src/fixtures/organizationFixtures.js
@@ -1,0 +1,33 @@
+const organizationFixtures = {
+  oneOrganization: [
+    {
+      id: 1,
+      name: "SB Hacks",
+      description: "Student run Hackathon at UCSB",
+    },
+  ],
+
+  threeRestaurants: [
+    {
+      id: 2,
+      name: "ACM",
+      description:
+        "The main CS club at UCSB.  They have a lot of fun events and are a great way to meet other CS students",
+    },
+
+    {
+      id: 3,
+      name: "Data Science Club",
+      description: "A club for students interested in data science.  They have workshops and projects related to data science and machine learning",
+    },
+
+    {
+      id: 4,
+      name: "UCSB Sports Analytics Club",
+      description:
+        "A club for students interested in sports analytics.  They have workshops and projects related to sports analytics and machine learning",
+    },
+  ],
+};
+
+export { organizationFixtures };

--- a/frontend/src/fixtures/organizationFixtures.js
+++ b/frontend/src/fixtures/organizationFixtures.js
@@ -18,7 +18,8 @@ const organizationFixtures = {
     {
       id: 3,
       name: "Data Science Club",
-      description: "A club for students interested in data science.  They have workshops and projects related to data science and machine learning",
+      description:
+        "A club for students interested in data science.  They have workshops and projects related to data science and machine learning",
     },
 
     {

--- a/frontend/src/main/components/UCSBOrganization/UCSBOrganizationForm.jsx
+++ b/frontend/src/main/components/UCSBOrganization/UCSBOrganizationForm.jsx
@@ -1,0 +1,121 @@
+import { Button, Form } from "react-bootstrap";
+import { useForm } from "react-hook-form";
+import { useNavigate } from "react-router";
+
+function UCSBOrganizationForm({
+  initialContents,
+  submitAction,
+  buttonLabel = "Create",
+}) {
+  // Stryker disable all
+  const {
+    register,
+    formState: { errors },
+    handleSubmit,
+  } = useForm({ defaultValues: initialContents || {} });
+  // Stryker restore all
+
+  const navigate = useNavigate();
+
+  const testIdPrefix = "UCSBOrganizationForm";
+
+  return (
+    <Form onSubmit={handleSubmit(submitAction)}>
+      {initialContents && (
+        <Form.Group className="mb-3">
+          <Form.Label htmlFor="orgCode">Organization Code</Form.Label>
+          <Form.Control
+            data-testid={testIdPrefix + "-orgCode"}
+            id="orgCode"
+            type="text"
+            {...register("orgCode")}
+            value={initialContents.orgCode}
+            disabled
+          />
+        </Form.Group>
+      )}
+
+      {!initialContents && (
+        <Form.Group className="mb-3">
+          <Form.Label htmlFor="orgCode">Organization Code</Form.Label>
+          <Form.Control
+            data-testid={testIdPrefix + "-orgCode"}
+            id="orgCode"
+            type="text"
+            isInvalid={Boolean(errors.orgCode)}
+            {...register("orgCode", {
+              required: "Organization code is required.",
+              maxLength: {
+                value: 30,
+                message: "Max length 30 characters",
+              },
+            })}
+          />
+          <Form.Control.Feedback type="invalid">
+            {errors.orgCode?.message}
+          </Form.Control.Feedback>
+        </Form.Group>
+      )}
+
+      <Form.Group className="mb-3">
+        <Form.Label htmlFor="orgTranslationShort">
+          Organization Short Name
+        </Form.Label>
+        <Form.Control
+          data-testid={testIdPrefix + "-orgTranslationShort"}
+          id="orgTranslationShort"
+          type="text"
+          isInvalid={Boolean(errors.orgTranslationShort)}
+          {...register("orgTranslationShort", {
+            required: "Organization short name is required.",
+          })}
+        />
+        <Form.Control.Feedback type="invalid">
+          {errors.orgTranslationShort?.message}
+        </Form.Control.Feedback>
+      </Form.Group>
+
+      <Form.Group className="mb-3">
+        <Form.Label htmlFor="orgTranslation">Organization Name</Form.Label>
+        <Form.Control
+          data-testid={testIdPrefix + "-orgTranslation"}
+          id="orgTranslation"
+          type="text"
+          isInvalid={Boolean(errors.orgTranslation)}
+          {...register("orgTranslation", {
+            required: "Organization name is required.",
+          })}
+        />
+        <Form.Control.Feedback type="invalid">
+          {errors.orgTranslation?.message}
+        </Form.Control.Feedback>
+      </Form.Group>
+
+      <Form.Group className="mb-3">
+        <Form.Check
+          data-testid={testIdPrefix + "-inactive"}
+          id="inactive"
+          type="checkbox"
+          label="Inactive"
+          {...register("inactive")}
+        />
+        <Form.Control.Feedback type="invalid">
+          {errors.inactive?.message}
+        </Form.Control.Feedback>
+      </Form.Group>
+
+      <Button type="submit" data-testid={testIdPrefix + "-submit"}>
+        {buttonLabel}
+      </Button>
+      <Button
+        variant="Secondary"
+        onClick={() => navigate(-1)}
+        data-testid={testIdPrefix + "-cancel"}
+      >
+        Cancel
+      </Button>
+    </Form>
+  );
+}
+
+export default UCSBOrganizationForm;

--- a/frontend/src/stories/components/UCSBOrganization/UCSBOrganizationForm.stories.jsx
+++ b/frontend/src/stories/components/UCSBOrganization/UCSBOrganizationForm.stories.jsx
@@ -1,0 +1,33 @@
+import React from "react";
+import UCSBOrganizationForm from "main/components/UCSBOrganization/UCSBOrganizationForm";
+import { organizationFixtures } from "fixtures/organizationFixtures";
+
+export default {
+  title: "components/UCSBOrganization/UCSBOrganizationForm",
+  component: UCSBOrganizationForm,
+};
+
+const Template = (args) => {
+  return <UCSBOrganizationForm {...args} />;
+};
+
+export const Create = Template.bind({});
+
+Create.args = {
+  buttonLabel: "Create",
+  submitAction: (data) => {
+    console.log("Submit was clicked with data: ", data);
+    window.alert("Submit was clicked with data: " + JSON.stringify(data));
+  },
+};
+
+export const Update = Template.bind({});
+
+Update.args = {
+  initialContents: organizationFixtures.oneOrganization[0],
+  buttonLabel: "Update",
+  submitAction: (data) => {
+    console.log("Submit was clicked with data: ", data);
+    window.alert("Submit was clicked with data: " + JSON.stringify(data));
+  },
+};

--- a/frontend/src/tests/components/UCSBOrganization/UCSBOrganizationForm.test.jsx
+++ b/frontend/src/tests/components/UCSBOrganization/UCSBOrganizationForm.test.jsx
@@ -41,6 +41,14 @@ describe("UCSBOrganizationForm tests", () => {
       const header = screen.getByText(headerText);
       expect(header).toBeInTheDocument();
     });
+
+    expect(screen.getByTestId(`${testId}-orgCode`)).toBeInTheDocument();
+    expect(
+      screen.getByTestId(`${testId}-orgTranslationShort`),
+    ).toBeInTheDocument();
+    expect(screen.getByTestId(`${testId}-orgTranslation`)).toBeInTheDocument();
+    expect(screen.getByTestId(`${testId}-inactive`)).toBeInTheDocument();
+    expect(screen.getByTestId(`${testId}-submit`)).toBeInTheDocument();
   });
 
   test("renders correctly when passing in initialContents", async () => {
@@ -54,6 +62,14 @@ describe("UCSBOrganizationForm tests", () => {
     expect(await screen.findByTestId(`${testId}-orgCode`)).toBeInTheDocument();
     expect(screen.getByTestId(`${testId}-orgCode`)).toHaveValue("ACM");
     expect(screen.getByTestId(`${testId}-orgCode`)).toBeDisabled();
+    expect(
+      screen.getByTestId(`${testId}-orgTranslationShort`),
+    ).toHaveValue("ACM");
+    expect(screen.getByTestId(`${testId}-orgTranslation`)).toHaveValue(
+      "Association for Computing Machinery",
+    );
+    expect(screen.getByTestId(`${testId}-inactive`)).not.toBeChecked();
+    expect(screen.getByTestId(`${testId}-submit`)).toBeInTheDocument();
   });
 
   test("that navigate(-1) is called when Cancel is clicked", async () => {
@@ -79,7 +95,7 @@ describe("UCSBOrganizationForm tests", () => {
     );
 
     expect(await screen.findByText(/Create/)).toBeInTheDocument();
-    const submitButton = screen.getByText(/Create/);
+    const submitButton = screen.getByTestId(`${testId}-submit`);
     fireEvent.click(submitButton);
 
     await screen.findByText(/Organization code is required./);
@@ -91,6 +107,16 @@ describe("UCSBOrganizationForm tests", () => {
     ).toBeInTheDocument();
 
     const orgCodeInput = screen.getByTestId(`${testId}-orgCode`);
+    const orgTranslationShortInput = screen.getByTestId(
+      `${testId}-orgTranslationShort`,
+    );
+    const orgTranslationInput = screen.getByTestId(`${testId}-orgTranslation`);
+    const inactiveInput = screen.getByTestId(`${testId}-inactive`);
+
+    expect(orgTranslationShortInput).toBeInTheDocument();
+    expect(orgTranslationInput).toBeInTheDocument();
+    expect(inactiveInput).toBeInTheDocument();
+
     fireEvent.change(orgCodeInput, { target: { value: "a".repeat(31) } });
     fireEvent.click(submitButton);
 

--- a/frontend/src/tests/components/UCSBOrganization/UCSBOrganizationForm.test.jsx
+++ b/frontend/src/tests/components/UCSBOrganization/UCSBOrganizationForm.test.jsx
@@ -1,0 +1,101 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { BrowserRouter as Router } from "react-router";
+
+import UCSBOrganizationForm from "main/components/UCSBOrganization/UCSBOrganizationForm";
+
+const mockedNavigate = vi.fn();
+vi.mock("react-router", async () => {
+  const originalModule = await vi.importActual("react-router");
+  return {
+    ...originalModule,
+    useNavigate: () => mockedNavigate,
+  };
+});
+
+describe("UCSBOrganizationForm tests", () => {
+  const expectedHeaders = [
+    "Organization Code",
+    "Organization Short Name",
+    "Organization Name",
+    "Inactive",
+  ];
+  const testId = "UCSBOrganizationForm";
+
+  const sampleOrganization = {
+    orgCode: "ACM",
+    orgTranslationShort: "ACM",
+    orgTranslation: "Association for Computing Machinery",
+    inactive: false,
+  };
+
+  test("renders correctly with no initialContents", async () => {
+    render(
+      <Router>
+        <UCSBOrganizationForm />
+      </Router>,
+    );
+
+    expect(await screen.findByText(/Create/)).toBeInTheDocument();
+
+    expectedHeaders.forEach((headerText) => {
+      const header = screen.getByText(headerText);
+      expect(header).toBeInTheDocument();
+    });
+  });
+
+  test("renders correctly when passing in initialContents", async () => {
+    render(
+      <Router>
+        <UCSBOrganizationForm initialContents={sampleOrganization} />
+      </Router>,
+    );
+
+    expect(await screen.findByText(/Create/)).toBeInTheDocument();
+    expect(await screen.findByTestId(`${testId}-orgCode`)).toBeInTheDocument();
+    expect(screen.getByTestId(`${testId}-orgCode`)).toHaveValue("ACM");
+    expect(screen.getByTestId(`${testId}-orgCode`)).toBeDisabled();
+  });
+
+  test("that navigate(-1) is called when Cancel is clicked", async () => {
+    render(
+      <Router>
+        <UCSBOrganizationForm />
+      </Router>,
+    );
+
+    expect(await screen.findByTestId(`${testId}-cancel`)).toBeInTheDocument();
+    const cancelButton = screen.getByTestId(`${testId}-cancel`);
+
+    fireEvent.click(cancelButton);
+
+    await waitFor(() => expect(mockedNavigate).toHaveBeenCalledWith(-1));
+  });
+
+  test("that the correct validations are performed", async () => {
+    render(
+      <Router>
+        <UCSBOrganizationForm />
+      </Router>,
+    );
+
+    expect(await screen.findByText(/Create/)).toBeInTheDocument();
+    const submitButton = screen.getByText(/Create/);
+    fireEvent.click(submitButton);
+
+    await screen.findByText(/Organization code is required./);
+    expect(
+      screen.getByText(/Organization short name is required./),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(/Organization name is required./),
+    ).toBeInTheDocument();
+
+    const orgCodeInput = screen.getByTestId(`${testId}-orgCode`);
+    fireEvent.change(orgCodeInput, { target: { value: "a".repeat(31) } });
+    fireEvent.click(submitButton);
+
+    await waitFor(() => {
+      expect(screen.getByText(/Max length 30 characters/)).toBeInTheDocument();
+    });
+  });
+});

--- a/frontend/src/tests/components/UCSBOrganization/UCSBOrganizationForm.test.jsx
+++ b/frontend/src/tests/components/UCSBOrganization/UCSBOrganizationForm.test.jsx
@@ -62,9 +62,9 @@ describe("UCSBOrganizationForm tests", () => {
     expect(await screen.findByTestId(`${testId}-orgCode`)).toBeInTheDocument();
     expect(screen.getByTestId(`${testId}-orgCode`)).toHaveValue("ACM");
     expect(screen.getByTestId(`${testId}-orgCode`)).toBeDisabled();
-    expect(
-      screen.getByTestId(`${testId}-orgTranslationShort`),
-    ).toHaveValue("ACM");
+    expect(screen.getByTestId(`${testId}-orgTranslationShort`)).toHaveValue(
+      "ACM",
+    );
     expect(screen.getByTestId(`${testId}-orgTranslation`)).toHaveValue(
       "Association for Computing Machinery",
     );


### PR DESCRIPTION
Closes #13

## What changed
Added `UCSBOrganizationForm` fields, fixtures, tests, and Storybook stories so the frontend matches the `UCSBOrganization` backend model and can be validated visually and in component tests.

## Testing
Test by running `cd frontend && npx vitest run --coverage=false src/tests/components/UCSBOrganization/UCSBOrganizationForm.test.jsx` and opening the `UCSBOrganizationForm` Create/Update stories in Storybook.

<img width="1503" height="834" alt="image" src="https://github.com/user-attachments/assets/e5b171dc-ed98-4348-a1fa-6b65e22eae36" />

