### PR TITLE
Jw menu item review create page

### DIFF
--- a/frontend/src/main/pages/MenuItemReviews/MenuItemReviewsCreatePage.jsx
+++ b/frontend/src/main/pages/MenuItemReviews/MenuItemReviewsCreatePage.jsx
@@ -1,11 +1,50 @@
 import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
+import MenuItemReviewForm from "main/components/MenuItemReviews/MenuItemReviewForm";
+import { Navigate } from "react-router";
+import { useBackendMutation } from "main/utils/useBackend";
+import { toast } from "react-toastify";
 
-export default function MenuItemReviewsCreatePage() {
-  // Stryker disable all : placeholder for future implementation
+export default function MenuItemReviewsCreatePage({ storybook = false }) {
+  const objectToAxiosParams = (menuItemReview) => ({
+    url: "/api/menuitemreviews/post",
+    method: "POST",
+    params: {
+      itemId: menuItemReview.itemId,
+      reviewerEmail: menuItemReview.reviewerEmail,
+      stars: menuItemReview.stars,
+      dateReviewed: menuItemReview.dateReviewed,
+      comments: menuItemReview.comments,
+    },
+  });
+
+  const onSuccess = (menuItemReview) => {
+    toast(
+      `New menuItemReview Created - id: ${menuItemReview.id} comments: ${menuItemReview.comments}`,
+    );
+  };
+
+  const mutation = useBackendMutation(
+    objectToAxiosParams,
+    { onSuccess },
+    // Stryker disable next-line all : hard to set up test for caching
+    ["/api/menuitemreviews/all"], // mutation makes this key stale so that pages relying on it reload
+  );
+
+  const { isSuccess } = mutation;
+
+  const onSubmit = async (data) => {
+    mutation.mutate(data);
+  };
+
+  if (isSuccess && !storybook) {
+    return <Navigate to="/menuitemreviews" />;
+  }
+
   return (
     <BasicLayout>
       <div className="pt-2">
-        <h1>Create page not yet implemented</h1>
+        <h1>Create New MenuItemReview</h1>
+        <MenuItemReviewForm submitAction={onSubmit} />
       </div>
     </BasicLayout>
   );

--- a/frontend/src/stories/pages/MenuItemReviews/MenuItemReviewsCreatePage.stories.jsx
+++ b/frontend/src/stories/pages/MenuItemReviews/MenuItemReviewsCreatePage.stories.jsx
@@ -1,0 +1,32 @@
+import React from "react";
+import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
+import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
+import { http, HttpResponse } from "msw";
+
+import MenuItemReviewsCreatePage from "main/pages/MenuItemReviews/MenuItemReviewsCreatePage";
+
+export default {
+  title: "pages/MenuItemReviews/MenuItemReviewsCreatePage",
+  component: MenuItemReviewsCreatePage,
+};
+
+const Template = () => <MenuItemReviewsCreatePage storybook={true} />;
+
+export const Default = Template.bind({});
+Default.parameters = {
+  msw: [
+    http.get("/api/currentUser", () => {
+      return HttpResponse.json(apiCurrentUserFixtures.userOnly, {
+        status: 200,
+      });
+    }),
+    http.get("/api/systemInfo", () => {
+      return HttpResponse.json(systemInfoFixtures.showingNeither, {
+        status: 200,
+      });
+    }),
+    http.post("/api/menuitemreviews/post", () => {
+      return HttpResponse.json({}, { status: 200 });
+    }),
+  ],
+};

--- a/frontend/src/tests/pages/MenuItemReviews/MenuItemReviewsCreatePage.test.jsx
+++ b/frontend/src/tests/pages/MenuItemReviews/MenuItemReviewsCreatePage.test.jsx
@@ -1,18 +1,40 @@
-import { render, screen } from "@testing-library/react";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import MenuItemReviewsCreatePage from "main/pages/MenuItemReviews/MenuItemReviewsCreatePage";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { MemoryRouter } from "react-router";
 
 import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
 import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
+
 import axios from "axios";
 import AxiosMockAdapter from "axios-mock-adapter";
-import { expect } from "vitest";
+
+const mockToast = vi.fn();
+vi.mock("react-toastify", async (importOriginal) => {
+  const originalModule = await importOriginal();
+  return {
+    ...originalModule,
+    toast: vi.fn((x) => mockToast(x)),
+  };
+});
+
+const mockNavigate = vi.fn();
+vi.mock("react-router", async (importOriginal) => {
+  const originalModule = await importOriginal();
+  return {
+    ...originalModule,
+    Navigate: vi.fn((x) => {
+      mockNavigate(x);
+      return null;
+    }),
+  };
+});
 
 describe("MenuItemReviewsCreatePage tests", () => {
   const axiosMock = new AxiosMockAdapter(axios);
 
-  const setupUserOnly = () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
     axiosMock.reset();
     axiosMock.resetHistory();
     axiosMock
@@ -21,15 +43,10 @@ describe("MenuItemReviewsCreatePage tests", () => {
     axiosMock
       .onGet("/api/systemInfo")
       .reply(200, systemInfoFixtures.showingNeither);
-  };
+  });
 
   const queryClient = new QueryClient();
-  test("Renders expected content", async () => {
-    // arrange
-
-    setupUserOnly();
-
-    // act
+  test("renders without crashing", async () => {
     render(
       <QueryClientProvider client={queryClient}>
         <MemoryRouter>
@@ -38,11 +55,81 @@ describe("MenuItemReviewsCreatePage tests", () => {
       </QueryClientProvider>,
     );
 
-    // assert
+    await waitFor(() => {
+      expect(screen.getByLabelText("Comments")).toBeInTheDocument();
+    });
+  });
 
-    await screen.findByText("Create page not yet implemented");
-    expect(
-      screen.getByText("Create page not yet implemented"),
-    ).toBeInTheDocument();
+  test("on submit, makes request to backend, and redirects to /menuitemreviews", async () => {
+    const queryClient = new QueryClient();
+
+    const menuItemReview = {
+      id: 3,
+      itemId: 4,
+      reviewerEmail: "joaquinwong@ucsb.edu",
+      stars: 5,
+      dateReviewed: "2022-02-02T00:00",
+      comments: "Good",
+    };
+
+    axiosMock.onPost("/api/menuitemreviews/post").reply(202, menuItemReview);
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <MenuItemReviewsCreatePage />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByLabelText("Comments")).toBeInTheDocument();
+    });
+
+    const commentsInput = screen.getByLabelText("Comments");
+    expect(commentsInput).toBeInTheDocument();
+
+    const itemIdInput = screen.getByLabelText("ItemId");
+    expect(itemIdInput).toBeInTheDocument();
+
+    const reviewerEmailInput = screen.getByLabelText("ReviewerEmail");
+    expect(reviewerEmailInput).toBeInTheDocument();
+
+    const starsInput = screen.getByLabelText("Stars");
+    expect(starsInput).toBeInTheDocument();
+
+    const dateReviewedInput = screen.getByLabelText("DateReviewed(iso format)");
+    expect(dateReviewedInput).toBeInTheDocument();
+
+    const createButton = screen.getByText("Create");
+    expect(createButton).toBeInTheDocument();
+
+    fireEvent.change(commentsInput, { target: { value: "Good" } });
+    fireEvent.change(itemIdInput, { target: { value: "4" } });
+    fireEvent.change(reviewerEmailInput, {
+      target: { value: "joaquinwong@ucsb.edu" },
+    });
+    fireEvent.change(starsInput, { target: { value: "5" } });
+    fireEvent.change(dateReviewedInput, {
+      target: { value: "2022-02-02T00:00" },
+    });
+
+    fireEvent.click(createButton);
+
+    await waitFor(() => expect(axiosMock.history.post.length).toBe(1));
+
+    expect(axiosMock.history.post[0].params).toEqual({
+      itemId: "4",
+      reviewerEmail: "joaquinwong@ucsb.edu",
+      stars: "5",
+      dateReviewed: "2022-02-02T00:00",
+      comments: "Good",
+    });
+
+    // assert - check that the toast was called with the expected message
+    expect(mockToast).toBeCalledWith(
+      "New menuItemReview Created - id: 3 comments: Good",
+    );
+    expect(mockNavigate).toBeCalledWith({ to: "/menuitemreviews" });
   });
 });


### PR DESCRIPTION
Closes #34 

Replaced the placeholder for MenuItemReviews Create Page with an actual Create Page.
Can test on dokku(Need to Login first, then try entering data in the Create Page of MenuItemReviews, then check if the data is populated in Swagger-UI): https://team02-joaquin-wong-dev.dokku-13.cs.ucsb.edu/

Also can see on storybook: https://69f40dc1c277d89602816733-cxcoigxsgc.chromatic.com/?path=/story/pages-menuitemreviews-menuitemreviewscreatepage--default
<img width="2870" height="1316" alt="image" src="https://github.com/user-attachments/assets/480cb5d7-5ce7-4b47-b6cf-bd34fda5693a" />
