### PR TITLE
Organization create page + 100% coverage of testing

### DIFF
--- a/frontend/src/main/pages/UCSBOrganization/UCSBOrganizationCreatePage.jsx
+++ b/frontend/src/main/pages/UCSBOrganization/UCSBOrganizationCreatePage.jsx
@@ -1,0 +1,50 @@
+import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
+import UCSBOrganizationForm from "main/components/UCSBOrganization/UCSBOrganizationForm";
+import { Navigate } from "react-router";
+import { useBackendMutation } from "main/utils/useBackend";
+import { toast } from "react-toastify";
+
+export default function UCSBOrganizationCreatePage({ storybook = false }) {
+  const objectToAxiosParams = (organization) => ({
+    url: "/api/ucsborganization/post",
+    method: "POST",
+    params: {
+      orgCode: organization.orgCode,
+      orgTranslationShort: organization.orgTranslationShort,
+      orgTranslation: organization.orgTranslation,
+      inactive: organization.inactive,
+    },
+  });
+
+  const onSuccess = (organization) => {
+    toast(
+      `New UCSBOrganization Created - orgCode: ${organization.orgCode} orgTranslationShort: ${organization.orgTranslationShort}`,
+    );
+  };
+
+  const mutation = useBackendMutation(
+    objectToAxiosParams,
+    { onSuccess },
+    // Stryker disable next-line all : hard to set up test for caching
+    ["/api/ucsborganization/all"],
+  );
+
+  const { isSuccess } = mutation;
+
+  const onSubmit = async (data) => {
+    mutation.mutate(data);
+  };
+
+  if (isSuccess && !storybook) {
+    return <Navigate to="/ucsborganization" />;
+  }
+
+  return (
+    <BasicLayout>
+      <div className="pt-2">
+        <h1>Create New UCSBOrganization</h1>
+        <UCSBOrganizationForm submitAction={onSubmit} />
+      </div>
+    </BasicLayout>
+  );
+}

--- a/frontend/src/stories/pages/UCSBOrganization/UCSBOrganizationCreatePage.stories.jsx
+++ b/frontend/src/stories/pages/UCSBOrganization/UCSBOrganizationCreatePage.stories.jsx
@@ -1,0 +1,32 @@
+import React from "react";
+import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
+import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
+import { http, HttpResponse } from "msw";
+
+import UCSBOrganizationCreatePage from "main/pages/UCSBOrganization/UCSBOrganizationCreatePage";
+
+export default {
+  title: "pages/UCSBOrganization/UCSBOrganizationCreatePage",
+  component: UCSBOrganizationCreatePage,
+};
+
+const Template = () => <UCSBOrganizationCreatePage storybook={true} />;
+
+export const Default = Template.bind({});
+Default.parameters = {
+  msw: [
+    http.get("/api/currentUser", () => {
+      return HttpResponse.json(apiCurrentUserFixtures.userOnly, {
+        status: 200,
+      });
+    }),
+    http.get("/api/systemInfo", () => {
+      return HttpResponse.json(systemInfoFixtures.showingNeither, {
+        status: 200,
+      });
+    }),
+    http.post("/api/ucsborganization/post", () => {
+      return HttpResponse.json({}, { status: 200 });
+    }),
+  ],
+};

--- a/frontend/src/tests/App.test.jsx
+++ b/frontend/src/tests/App.test.jsx
@@ -62,7 +62,7 @@ describe("App route tests", () => {
     );
 
     expect(
-      await screen.findByText("Create page not yet implemented"),
+      await screen.findByText("Create New UCSBOrganization"),
     ).toBeInTheDocument();
   });
 

--- a/frontend/src/tests/pages/UCSBOrganization/UCSBOrganizationCreatePage.test.jsx
+++ b/frontend/src/tests/pages/UCSBOrganization/UCSBOrganizationCreatePage.test.jsx
@@ -1,0 +1,126 @@
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import UCSBOrganizationCreatePage from "main/pages/UCSBOrganization/UCSBOrganizationCreatePage";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { MemoryRouter } from "react-router";
+
+import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
+import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
+
+import axios from "axios";
+import AxiosMockAdapter from "axios-mock-adapter";
+
+const mockToast = vi.fn();
+vi.mock("react-toastify", async (importOriginal) => {
+  const originalModule = await importOriginal();
+  return {
+    ...originalModule,
+    toast: vi.fn((x) => mockToast(x)),
+  };
+});
+
+const mockNavigate = vi.fn();
+vi.mock("react-router", async (importOriginal) => {
+  const originalModule = await importOriginal();
+  return {
+    ...originalModule,
+    Navigate: vi.fn((x) => {
+      mockNavigate(x);
+      return null;
+    }),
+  };
+});
+
+describe("UCSBOrganizationCreatePage tests", () => {
+  const axiosMock = new AxiosMockAdapter(axios);
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    axiosMock.reset();
+    axiosMock.resetHistory();
+    axiosMock
+      .onGet("/api/currentUser")
+      .reply(200, apiCurrentUserFixtures.userOnly);
+    axiosMock
+      .onGet("/api/systemInfo")
+      .reply(200, systemInfoFixtures.showingNeither);
+  });
+
+  test("renders without crashing", async () => {
+    const queryClient = new QueryClient();
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <UCSBOrganizationCreatePage />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    await waitFor(() => {
+      expect(
+        screen.getByTestId("UCSBOrganizationForm-orgCode"),
+      ).toBeInTheDocument();
+    });
+  });
+
+  test("on submit, makes request to backend, and redirects to /ucsborganization", async () => {
+    const queryClient = new QueryClient();
+    const organization = {
+      orgCode: "SBHACKS",
+      orgTranslationShort: "SB Hacks",
+      orgTranslation: "Student-run Hackathon at UCSB",
+      inactive: false,
+    };
+
+    axiosMock.onPost("/api/ucsborganization/post").reply(202, organization);
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <UCSBOrganizationCreatePage />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    await waitFor(() => {
+      expect(
+        screen.getByTestId("UCSBOrganizationForm-orgCode"),
+      ).toBeInTheDocument();
+    });
+
+    const orgCodeInput = screen.getByTestId("UCSBOrganizationForm-orgCode");
+    const orgTranslationShortInput = screen.getByTestId(
+      "UCSBOrganizationForm-orgTranslationShort",
+    );
+    const orgTranslationInput = screen.getByTestId(
+      "UCSBOrganizationForm-orgTranslation",
+    );
+    const inactiveInput = screen.getByTestId("UCSBOrganizationForm-inactive");
+    const createButton = screen.getByTestId("UCSBOrganizationForm-submit");
+
+    fireEvent.change(orgCodeInput, { target: { value: "SBHACKS" } });
+    fireEvent.change(orgTranslationShortInput, {
+      target: { value: "SB Hacks" },
+    });
+    fireEvent.change(orgTranslationInput, {
+      target: { value: "Student-run Hackathon at UCSB" },
+    });
+    fireEvent.click(inactiveInput);
+    fireEvent.click(inactiveInput);
+    fireEvent.click(createButton);
+
+    await waitFor(() => expect(axiosMock.history.post.length).toBe(1));
+
+    expect(axiosMock.history.post[0].params).toEqual({
+      orgCode: "SBHACKS",
+      orgTranslationShort: "SB Hacks",
+      orgTranslation: "Student-run Hackathon at UCSB",
+      inactive: false,
+    });
+
+    expect(mockToast).toBeCalledWith(
+      "New UCSBOrganization Created - orgCode: SBHACKS orgTranslationShort: SB Hacks",
+    );
+    expect(mockNavigate).toBeCalledWith({ to: "/ucsborganization" });
+  });
+});


### PR DESCRIPTION
Add Create Page functionality for UCSBOrganization

Closes #16 

## What Changed
Edit UCSBOrganizationCreatePage.js, and also UCSBOrganizationCreatePage.test.js and UCSBOrganizationCreatePage.stories.js for testing

## Why
Frontend functionality to connect to backend for the creation of UCSBOrganization

## Testing
Run locally and check page or check Storybook

Picture:
<img width="1197" height="649" alt="image" src="https://github.com/user-attachments/assets/2cb91187-3951-41e4-bce3-69539c3bc977" />