### PR TITLE
as -  finalpr for team02!

### DIFF
--- a/frontend/src/main/pages/RecommendationRequest/RecommendationRequestCreatePage.jsx
+++ b/frontend/src/main/pages/RecommendationRequest/RecommendationRequestCreatePage.jsx
@@ -1,11 +1,51 @@
 import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
+import RecommendationRequestForm from "main/components/RecommendationRequest/RecommendationRequestForm";
+import { Navigate } from "react-router";
+import { useBackendMutation } from "main/utils/useBackend";
+import { toast } from "react-toastify";
 
-export default function RecommendationRequestCreatePage() {
-  // Stryker disable all : placeholder for future implementation
+export default function RecommendationRequestCreatePage({ storybook = false }) {
+  const objectToAxiosParams = (recommendationRequest) => ({
+    url: "/api/recommendationrequests/post",
+    method: "POST",
+    params: {
+      requesterEmail: recommendationRequest.requesterEmail,
+      professorEmail: recommendationRequest.professorEmail,
+      explanation: recommendationRequest.explanation,
+      dateRequested: recommendationRequest.dateRequested,
+      dateNeeded: recommendationRequest.dateNeeded,
+      done: recommendationRequest.done,
+    },
+  });
+
+  const onSuccess = (recommendationRequest) => {
+    toast(
+      `New RecommendationRequest Created - id: ${recommendationRequest.id} requesterEmail: ${recommendationRequest.requesterEmail}`,
+    );
+  };
+
+  const mutation = useBackendMutation(
+    objectToAxiosParams,
+    { onSuccess },
+    // Stryker disable next-line all : hard to set up test for caching
+    ["/api/recommendationrequests/all"],
+  );
+
+  const { isSuccess } = mutation;
+
+  const onSubmit = async (data) => {
+    mutation.mutate(data);
+  };
+
+  if (isSuccess && !storybook) {
+    return <Navigate to="/recommendationrequest" />;
+  }
+
   return (
     <BasicLayout>
       <div className="pt-2">
-        <h1>Create page not yet implemented</h1>
+        <h1>Create New RecommendationRequest</h1>
+        <RecommendationRequestForm submitAction={onSubmit} />
       </div>
     </BasicLayout>
   );

--- a/frontend/src/main/pages/RecommendationRequest/RecommendationRequestEditPage.jsx
+++ b/frontend/src/main/pages/RecommendationRequest/RecommendationRequestEditPage.jsx
@@ -1,11 +1,80 @@
 import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
+import { useParams } from "react-router";
+import RecommendationRequestForm from "main/components/RecommendationRequest/RecommendationRequestForm";
+import { Navigate } from "react-router";
+import { useBackend, useBackendMutation } from "main/utils/useBackend";
+import { toast } from "react-toastify";
 
-export default function RecommendationRequestEditPage() {
-  // Stryker disable all : placeholder for future implementation
+export default function RecommendationRequestEditPage({ storybook = false }) {
+  let { id } = useParams();
+
+  const {
+    data: recommendationRequest,
+    _error,
+    _status,
+  } = useBackend(
+    // Stryker disable next-line all : don't test internal caching of React Query
+    [`/api/recommendationrequests?id=${id}`],
+    {
+      // Stryker disable next-line all : GET is the default, so mutating this to "" doesn't introduce a bug
+      method: "GET",
+      url: `/api/recommendationrequests`,
+      params: {
+        id,
+      },
+    },
+  );
+
+  const objectToAxiosPutParams = (recommendationRequest) => ({
+    url: "/api/recommendationrequests",
+    method: "PUT",
+    params: {
+      id: recommendationRequest.id,
+    },
+    data: {
+      requesterEmail: recommendationRequest.requesterEmail,
+      professorEmail: recommendationRequest.professorEmail,
+      explanation: recommendationRequest.explanation,
+      dateRequested: recommendationRequest.dateRequested,
+      dateNeeded: recommendationRequest.dateNeeded,
+      done: recommendationRequest.done,
+    },
+  });
+
+  const onSuccess = (recommendationRequest) => {
+    toast(
+      `RecommendationRequest Updated - id: ${recommendationRequest.id} requesterEmail: ${recommendationRequest.requesterEmail}`,
+    );
+  };
+
+  const mutation = useBackendMutation(
+    objectToAxiosPutParams,
+    { onSuccess },
+    // Stryker disable next-line all : hard to set up test for caching
+    [`/api/recommendationrequests?id=${id}`],
+  );
+
+  const { isSuccess } = mutation;
+
+  const onSubmit = async (data) => {
+    mutation.mutate(data);
+  };
+
+  if (isSuccess && !storybook) {
+    return <Navigate to="/recommendationrequest" />;
+  }
+
   return (
     <BasicLayout>
       <div className="pt-2">
-        <h1>Edit page not yet implemented</h1>
+        <h1>Edit RecommendationRequest</h1>
+        {recommendationRequest && (
+          <RecommendationRequestForm
+            submitAction={onSubmit}
+            buttonLabel={"Update"}
+            initialContents={recommendationRequest}
+          />
+        )}
       </div>
     </BasicLayout>
   );

--- a/frontend/src/main/pages/RecommendationRequest/RecommendationRequestIndexPage.jsx
+++ b/frontend/src/main/pages/RecommendationRequest/RecommendationRequestIndexPage.jsx
@@ -1,11 +1,48 @@
+import { useBackend } from "main/utils/useBackend";
+
 import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
+import RecommendationRequestTable from "main/components/RecommendationRequest/RecommendationRequestTable";
+import { useCurrentUser, hasRole } from "main/utils/useCurrentUser";
+import { Button } from "react-bootstrap";
 
 export default function RecommendationRequestIndexPage() {
-  // Stryker disable all : placeholder for future implementation
+  const currentUser = useCurrentUser();
+
+  const {
+    data: recommendationRequests,
+    error: _error,
+    status: _status,
+  } = useBackend(
+    // Stryker disable next-line all : don't test internal caching of React Query
+    ["/api/recommendationrequests/all"],
+    { method: "GET", url: "/api/recommendationrequests/all" },
+    // Stryker disable next-line all : don't test default value of empty list
+    [],
+  );
+
+  const createButton = () => {
+    if (hasRole(currentUser, "ROLE_ADMIN")) {
+      return (
+        <Button
+          variant="primary"
+          href="/recommendationrequest/create"
+          style={{ float: "right" }}
+        >
+          Create RecommendationRequest
+        </Button>
+      );
+    }
+  };
+
   return (
     <BasicLayout>
       <div className="pt-2">
-        <h1>Index page not yet implemented</h1>
+        {createButton()}
+        <h1>RecommendationRequests</h1>
+        <RecommendationRequestTable
+          recommendationRequests={recommendationRequests}
+          currentUser={currentUser}
+        />
       </div>
     </BasicLayout>
   );

--- a/frontend/src/stories/pages/RecommendationRequest/RecommendationRequestCreatePage.stories.jsx
+++ b/frontend/src/stories/pages/RecommendationRequest/RecommendationRequestCreatePage.stories.jsx
@@ -1,0 +1,32 @@
+import React from "react";
+import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
+import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
+import { http, HttpResponse } from "msw";
+
+import RecommendationRequestCreatePage from "main/pages/RecommendationRequest/RecommendationRequestCreatePage";
+
+export default {
+  title: "pages/RecommendationRequest/RecommendationRequestCreatePage",
+  component: RecommendationRequestCreatePage,
+};
+
+const Template = () => <RecommendationRequestCreatePage storybook={true} />;
+
+export const Default = Template.bind({});
+Default.parameters = {
+  msw: [
+    http.get("/api/currentUser", () => {
+      return HttpResponse.json(apiCurrentUserFixtures.userOnly, {
+        status: 200,
+      });
+    }),
+    http.get("/api/systemInfo", () => {
+      return HttpResponse.json(systemInfoFixtures.showingNeither, {
+        status: 200,
+      });
+    }),
+    http.post("/api/recommendationrequests/post", () => {
+      return HttpResponse.json({}, { status: 200 });
+    }),
+  ],
+};

--- a/frontend/src/stories/pages/RecommendationRequest/RecommendationRequestEditPage.stories.jsx
+++ b/frontend/src/stories/pages/RecommendationRequest/RecommendationRequestEditPage.stories.jsx
@@ -1,0 +1,39 @@
+import React from "react";
+import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
+import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
+import { recommendationRequestFixtures } from "fixtures/recommendationRequestFixtures";
+import { http, HttpResponse } from "msw";
+
+import RecommendationRequestEditPage from "main/pages/RecommendationRequest/RecommendationRequestEditPage";
+
+export default {
+  title: "pages/RecommendationRequest/RecommendationRequestEditPage",
+  component: RecommendationRequestEditPage,
+};
+
+const Template = () => <RecommendationRequestEditPage storybook={true} />;
+
+export const Default = Template.bind({});
+Default.parameters = {
+  msw: [
+    http.get("/api/currentUser", () => {
+      return HttpResponse.json(apiCurrentUserFixtures.userOnly, {
+        status: 200,
+      });
+    }),
+    http.get("/api/systemInfo", () => {
+      return HttpResponse.json(systemInfoFixtures.showingNeither, {
+        status: 200,
+      });
+    }),
+    http.get("/api/recommendationrequests", () => {
+      return HttpResponse.json(
+        recommendationRequestFixtures.oneRecommendationRequest,
+        { status: 200 },
+      );
+    }),
+    http.put("/api/recommendationrequests", () => {
+      return HttpResponse.json({}, { status: 200 });
+    }),
+  ],
+};

--- a/frontend/src/stories/pages/RecommendationRequest/RecommendationRequestIndexPage.stories.jsx
+++ b/frontend/src/stories/pages/RecommendationRequest/RecommendationRequestIndexPage.stories.jsx
@@ -1,0 +1,83 @@
+import React from "react";
+import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
+import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
+import { recommendationRequestFixtures } from "fixtures/recommendationRequestFixtures";
+import { http, HttpResponse } from "msw";
+
+import RecommendationRequestIndexPage from "main/pages/RecommendationRequest/RecommendationRequestIndexPage";
+
+export default {
+  title: "pages/RecommendationRequest/RecommendationRequestIndexPage",
+  component: RecommendationRequestIndexPage,
+};
+
+const Template = () => <RecommendationRequestIndexPage />;
+
+export const Empty = Template.bind({});
+Empty.parameters = {
+  msw: [
+    http.get("/api/currentUser", () => {
+      return HttpResponse.json(apiCurrentUserFixtures.userOnly, {
+        status: 200,
+      });
+    }),
+    http.get("/api/systemInfo", () => {
+      return HttpResponse.json(systemInfoFixtures.showingNeither, {
+        status: 200,
+      });
+    }),
+    http.get("/api/recommendationrequests/all", () => {
+      return HttpResponse.json([], { status: 200 });
+    }),
+  ],
+};
+
+export const ThreeItemsOrdinaryUser = Template.bind({});
+ThreeItemsOrdinaryUser.parameters = {
+  msw: [
+    http.get("/api/currentUser", () => {
+      return HttpResponse.json(apiCurrentUserFixtures.userOnly, {
+        status: 200,
+      });
+    }),
+    http.get("/api/systemInfo", () => {
+      return HttpResponse.json(systemInfoFixtures.showingNeither, {
+        status: 200,
+      });
+    }),
+    http.get("/api/recommendationrequests/all", () => {
+      return HttpResponse.json(
+        recommendationRequestFixtures.threeRecommendationRequests,
+        { status: 200 },
+      );
+    }),
+  ],
+};
+
+export const ThreeItemsAdminUser = Template.bind({});
+ThreeItemsAdminUser.parameters = {
+  msw: [
+    http.get("/api/currentUser", () => {
+      return HttpResponse.json(apiCurrentUserFixtures.adminUser, {
+        status: 200,
+      });
+    }),
+    http.get("/api/systemInfo", () => {
+      return HttpResponse.json(systemInfoFixtures.showingNeither, {
+        status: 200,
+      });
+    }),
+    http.get("/api/recommendationrequests/all", () => {
+      return HttpResponse.json(
+        recommendationRequestFixtures.threeRecommendationRequests,
+        { status: 200 },
+      );
+    }),
+    http.delete("/api/recommendationrequest", () => {
+      return HttpResponse.json(
+        { message: "RecommendationRequest deleted successfully" },
+        { status: 200 },
+      );
+    }),
+  ],
+};

--- a/frontend/src/tests/pages/RecommendationRequest/RecommendationRequestCreatePage.test.jsx
+++ b/frontend/src/tests/pages/RecommendationRequest/RecommendationRequestCreatePage.test.jsx
@@ -1,18 +1,40 @@
-import { render, screen } from "@testing-library/react";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import RecommendationRequestCreatePage from "main/pages/RecommendationRequest/RecommendationRequestCreatePage";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { MemoryRouter } from "react-router";
 
 import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
 import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
+
 import axios from "axios";
 import AxiosMockAdapter from "axios-mock-adapter";
-import { expect } from "vitest";
+
+const mockToast = vi.fn();
+vi.mock("react-toastify", async (importOriginal) => {
+  const originalModule = await importOriginal();
+  return {
+    ...originalModule,
+    toast: vi.fn((x) => mockToast(x)),
+  };
+});
+
+const mockNavigate = vi.fn();
+vi.mock("react-router", async (importOriginal) => {
+  const originalModule = await importOriginal();
+  return {
+    ...originalModule,
+    Navigate: vi.fn((x) => {
+      mockNavigate(x);
+      return null;
+    }),
+  };
+});
 
 describe("RecommendationRequestCreatePage tests", () => {
   const axiosMock = new AxiosMockAdapter(axios);
 
-  const setupUserOnly = () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
     axiosMock.reset();
     axiosMock.resetHistory();
     axiosMock
@@ -21,11 +43,39 @@ describe("RecommendationRequestCreatePage tests", () => {
     axiosMock
       .onGet("/api/systemInfo")
       .reply(200, systemInfoFixtures.showingNeither);
-  };
+  });
 
   const queryClient = new QueryClient();
-  test("Renders expected content", async () => {
-    setupUserOnly();
+
+  test("renders without crashing", async () => {
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <RecommendationRequestCreatePage />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByLabelText("Requester Email")).toBeInTheDocument();
+    });
+  });
+
+  test("on submit, makes request to backend, and redirects to /recommendationrequest", async () => {
+    const queryClient = new QueryClient();
+    const recommendationRequest = {
+      id: 1,
+      requesterEmail: "student@ucsb.edu",
+      professorEmail: "prof@ucsb.edu",
+      explanation: "Need rec for grad school",
+      dateRequested: "2024-01-15T00:00",
+      dateNeeded: "2024-03-01T00:00",
+      done: false,
+    };
+
+    axiosMock
+      .onPost("/api/recommendationrequests/post")
+      .reply(202, recommendationRequest);
 
     render(
       <QueryClientProvider client={queryClient}>
@@ -35,9 +85,42 @@ describe("RecommendationRequestCreatePage tests", () => {
       </QueryClientProvider>,
     );
 
-    await screen.findByText("Create page not yet implemented");
-    expect(
-      screen.getByText("Create page not yet implemented"),
-    ).toBeInTheDocument();
+    await waitFor(() => {
+      expect(screen.getByLabelText("Requester Email")).toBeInTheDocument();
+    });
+
+    fireEvent.change(screen.getByLabelText("Requester Email"), {
+      target: { value: "student@ucsb.edu" },
+    });
+    fireEvent.change(screen.getByLabelText("Professor Email"), {
+      target: { value: "prof@ucsb.edu" },
+    });
+    fireEvent.change(screen.getByLabelText("Explanation"), {
+      target: { value: "Need rec for grad school" },
+    });
+    fireEvent.change(screen.getByLabelText("Date Requested"), {
+      target: { value: "2024-01-15T00:00" },
+    });
+    fireEvent.change(screen.getByLabelText("Date Needed"), {
+      target: { value: "2024-03-01T00:00" },
+    });
+
+    fireEvent.click(screen.getByText("Create"));
+
+    await waitFor(() => expect(axiosMock.history.post.length).toBe(1));
+
+    expect(axiosMock.history.post[0].params).toEqual({
+      requesterEmail: "student@ucsb.edu",
+      professorEmail: "prof@ucsb.edu",
+      explanation: "Need rec for grad school",
+      dateRequested: "2024-01-15T00:00",
+      dateNeeded: "2024-03-01T00:00",
+      done: false,
+    });
+
+    expect(mockToast).toBeCalledWith(
+      "New RecommendationRequest Created - id: 1 requesterEmail: student@ucsb.edu",
+    );
+    expect(mockNavigate).toBeCalledWith({ to: "/recommendationrequest" });
   });
 });

--- a/frontend/src/tests/pages/RecommendationRequest/RecommendationRequestEditPage.test.jsx
+++ b/frontend/src/tests/pages/RecommendationRequest/RecommendationRequestEditPage.test.jsx
@@ -1,43 +1,214 @@
-import { render, screen } from "@testing-library/react";
-import RecommendationRequestEditPage from "main/pages/RecommendationRequest/RecommendationRequestEditPage";
+import { fireEvent, render, waitFor, screen } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { MemoryRouter } from "react-router";
+import RecommendationRequestEditPage from "main/pages/RecommendationRequest/RecommendationRequestEditPage";
 
 import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
 import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
 import axios from "axios";
 import AxiosMockAdapter from "axios-mock-adapter";
-import { expect } from "vitest";
+import mockConsole from "tests/testutils/mockConsole";
 
-describe("RecommendationRequestEditPage tests", () => {
-  const axiosMock = new AxiosMockAdapter(axios);
-
-  const setupUserOnly = () => {
-    axiosMock.reset();
-    axiosMock.resetHistory();
-    axiosMock
-      .onGet("/api/currentUser")
-      .reply(200, apiCurrentUserFixtures.userOnly);
-    axiosMock
-      .onGet("/api/systemInfo")
-      .reply(200, systemInfoFixtures.showingNeither);
+const mockToast = vi.fn();
+vi.mock("react-toastify", async (importOriginal) => {
+  const originalModule = await importOriginal();
+  return {
+    ...originalModule,
+    toast: vi.fn((x) => mockToast(x)),
   };
+});
 
-  const queryClient = new QueryClient();
-  test("Renders expected content", async () => {
-    setupUserOnly();
+const mockNavigate = vi.fn();
+vi.mock("react-router", async (importOriginal) => {
+  const originalModule = await importOriginal();
+  return {
+    ...originalModule,
+    useParams: vi.fn(() => ({
+      id: 1,
+    })),
+    Navigate: vi.fn((x) => {
+      mockNavigate(x);
+      return null;
+    }),
+  };
+});
 
-    render(
-      <QueryClientProvider client={queryClient}>
-        <MemoryRouter>
-          <RecommendationRequestEditPage />
-        </MemoryRouter>
-      </QueryClientProvider>,
-    );
+let axiosMock;
+describe("RecommendationRequestEditPage tests", () => {
+  describe("when the backend doesn't return data", () => {
+    beforeEach(() => {
+      axiosMock = new AxiosMockAdapter(axios);
+      axiosMock.reset();
+      axiosMock.resetHistory();
+      axiosMock
+        .onGet("/api/currentUser")
+        .reply(200, apiCurrentUserFixtures.userOnly);
+      axiosMock
+        .onGet("/api/systemInfo")
+        .reply(200, systemInfoFixtures.showingNeither);
+      axiosMock
+        .onGet("/api/recommendationrequests", { params: { id: 1 } })
+        .timeout();
+    });
 
-    await screen.findByText("Edit page not yet implemented");
-    expect(
-      screen.getByText("Edit page not yet implemented"),
-    ).toBeInTheDocument();
+    afterEach(() => {
+      mockToast.mockClear();
+      mockNavigate.mockClear();
+      axiosMock.restore();
+      axiosMock.resetHistory();
+    });
+
+    const queryClient = new QueryClient();
+    test("renders header but form is not present", async () => {
+      const restoreConsole = mockConsole();
+
+      render(
+        <QueryClientProvider client={queryClient}>
+          <MemoryRouter>
+            <RecommendationRequestEditPage />
+          </MemoryRouter>
+        </QueryClientProvider>,
+      );
+      await screen.findByText("Edit RecommendationRequest");
+      expect(
+        screen.queryByTestId("RecommendationRequestForm-requesterEmail"),
+      ).not.toBeInTheDocument();
+      restoreConsole();
+    });
+  });
+
+  describe("tests where backend is working normally", () => {
+    beforeEach(() => {
+      axiosMock = new AxiosMockAdapter(axios);
+      axiosMock.reset();
+      axiosMock.resetHistory();
+      axiosMock
+        .onGet("/api/currentUser")
+        .reply(200, apiCurrentUserFixtures.userOnly);
+      axiosMock
+        .onGet("/api/systemInfo")
+        .reply(200, systemInfoFixtures.showingNeither);
+      axiosMock
+        .onGet("/api/recommendationrequests", { params: { id: 1 } })
+        .reply(200, {
+          id: 1,
+          requesterEmail: "student@ucsb.edu",
+          professorEmail: "prof@ucsb.edu",
+          explanation: "Need rec for grad school",
+          dateRequested: "2024-01-15T00:00",
+          dateNeeded: "2024-03-01T00:00",
+          done: false,
+        });
+      axiosMock.onPut("/api/recommendationrequests").reply(200, {
+        id: 1,
+        requesterEmail: "updated@ucsb.edu",
+        professorEmail: "prof@ucsb.edu",
+        explanation: "Updated explanation",
+        dateRequested: "2024-01-15T00:00",
+        dateNeeded: "2024-03-01T00:00",
+        done: true,
+      });
+    });
+
+    afterEach(() => {
+      mockToast.mockClear();
+      mockNavigate.mockClear();
+      axiosMock.restore();
+      axiosMock.resetHistory();
+    });
+
+    const queryClient = new QueryClient();
+
+    test("Is populated with the data provided", async () => {
+      render(
+        <QueryClientProvider client={queryClient}>
+          <MemoryRouter>
+            <RecommendationRequestEditPage />
+          </MemoryRouter>
+        </QueryClientProvider>,
+      );
+
+      await screen.findByTestId("RecommendationRequestForm-id");
+
+      const idField = screen.getByTestId("RecommendationRequestForm-id");
+      const requesterEmailField = screen.getByTestId(
+        "RecommendationRequestForm-requesterEmail",
+      );
+      const professorEmailField = screen.getByTestId(
+        "RecommendationRequestForm-professorEmail",
+      );
+      const explanationField = screen.getByTestId(
+        "RecommendationRequestForm-explanation",
+      );
+      const submitButton = screen.getByTestId(
+        "RecommendationRequestForm-submit",
+      );
+
+      expect(idField).toHaveValue("1");
+      expect(requesterEmailField).toHaveValue("student@ucsb.edu");
+      expect(professorEmailField).toHaveValue("prof@ucsb.edu");
+      expect(explanationField).toHaveValue("Need rec for grad school");
+      expect(submitButton).toHaveTextContent("Update");
+
+      fireEvent.change(requesterEmailField, {
+        target: { value: "updated@ucsb.edu" },
+      });
+      fireEvent.change(explanationField, {
+        target: { value: "Updated explanation" },
+      });
+      fireEvent.click(submitButton);
+
+      await waitFor(() => expect(mockToast).toBeCalled());
+      expect(mockToast).toBeCalledWith(
+        "RecommendationRequest Updated - id: 1 requesterEmail: updated@ucsb.edu",
+      );
+      expect(mockNavigate).toBeCalledWith({ to: "/recommendationrequest" });
+
+      expect(axiosMock.history.put.length).toBe(1);
+      expect(axiosMock.history.put[0].params).toEqual({ id: 1 });
+      expect(axiosMock.history.put[0].data).toBe(
+        JSON.stringify({
+          requesterEmail: "updated@ucsb.edu",
+          professorEmail: "prof@ucsb.edu",
+          explanation: "Updated explanation",
+          dateRequested: "2024-01-15T00:00",
+          dateNeeded: "2024-03-01T00:00",
+          done: false,
+        }),
+      );
+    });
+
+    test("Changes when you click Update", async () => {
+      render(
+        <QueryClientProvider client={queryClient}>
+          <MemoryRouter>
+            <RecommendationRequestEditPage />
+          </MemoryRouter>
+        </QueryClientProvider>,
+      );
+
+      await screen.findByTestId("RecommendationRequestForm-id");
+
+      const requesterEmailField = screen.getByTestId(
+        "RecommendationRequestForm-requesterEmail",
+      );
+      const submitButton = screen.getByTestId(
+        "RecommendationRequestForm-submit",
+      );
+
+      expect(requesterEmailField).toHaveValue("student@ucsb.edu");
+      expect(submitButton).toBeInTheDocument();
+
+      fireEvent.change(requesterEmailField, {
+        target: { value: "updated@ucsb.edu" },
+      });
+      fireEvent.click(submitButton);
+
+      await waitFor(() => expect(mockToast).toBeCalled());
+      expect(mockToast).toBeCalledWith(
+        "RecommendationRequest Updated - id: 1 requesterEmail: updated@ucsb.edu",
+      );
+      expect(mockNavigate).toBeCalledWith({ to: "/recommendationrequest" });
+    });
   });
 });

--- a/frontend/src/tests/pages/RecommendationRequest/RecommendationRequestIndexPage.test.jsx
+++ b/frontend/src/tests/pages/RecommendationRequest/RecommendationRequestIndexPage.test.jsx
@@ -1,16 +1,28 @@
-import { render, screen } from "@testing-library/react";
+import { render, screen, waitFor, fireEvent } from "@testing-library/react";
 import RecommendationRequestIndexPage from "main/pages/RecommendationRequest/RecommendationRequestIndexPage";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { MemoryRouter } from "react-router";
+import mockConsole from "tests/testutils/mockConsole";
+import { recommendationRequestFixtures } from "fixtures/recommendationRequestFixtures";
 
 import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
 import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
 import axios from "axios";
 import AxiosMockAdapter from "axios-mock-adapter";
-import { expect } from "vitest";
+
+const mockToast = vi.fn();
+vi.mock("react-toastify", async (importOriginal) => {
+  const originalModule = await importOriginal();
+  return {
+    ...originalModule,
+    toast: vi.fn((x) => mockToast(x)),
+  };
+});
 
 describe("RecommendationRequestIndexPage tests", () => {
   const axiosMock = new AxiosMockAdapter(axios);
+
+  const testId = "RecommendationRequestTable";
 
   const setupUserOnly = () => {
     axiosMock.reset();
@@ -23,9 +35,22 @@ describe("RecommendationRequestIndexPage tests", () => {
       .reply(200, systemInfoFixtures.showingNeither);
   };
 
+  const setupAdminUser = () => {
+    axiosMock.reset();
+    axiosMock.resetHistory();
+    axiosMock
+      .onGet("/api/currentUser")
+      .reply(200, apiCurrentUserFixtures.adminUser);
+    axiosMock
+      .onGet("/api/systemInfo")
+      .reply(200, systemInfoFixtures.showingNeither);
+  };
+
   const queryClient = new QueryClient();
-  test("Renders expected content", async () => {
-    setupUserOnly();
+
+  test("Renders with Create Button for admin user", async () => {
+    setupAdminUser();
+    axiosMock.onGet("/api/recommendationrequests/all").reply(200, []);
 
     render(
       <QueryClientProvider client={queryClient}>
@@ -35,9 +60,130 @@ describe("RecommendationRequestIndexPage tests", () => {
       </QueryClientProvider>,
     );
 
-    await screen.findByText("Index page not yet implemented");
+    await waitFor(() => {
+      expect(
+        screen.getByText(/Create RecommendationRequest/),
+      ).toBeInTheDocument();
+    });
+    const button = screen.getByText(/Create RecommendationRequest/);
+    expect(button).toHaveAttribute("href", "/recommendationrequest/create");
+    expect(button).toHaveAttribute("style", "float: right;");
+  });
+
+  test("renders three recommendation requests correctly for regular user", async () => {
+    setupUserOnly();
+    axiosMock
+      .onGet("/api/recommendationrequests/all")
+      .reply(200, recommendationRequestFixtures.threeRecommendationRequests);
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <RecommendationRequestIndexPage />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    await waitFor(() => {
+      expect(
+        screen.getByTestId(`${testId}-cell-row-0-col-id`),
+      ).toHaveTextContent("1");
+    });
+    expect(screen.getByTestId(`${testId}-cell-row-1-col-id`)).toHaveTextContent(
+      "2",
+    );
+    expect(screen.getByTestId(`${testId}-cell-row-2-col-id`)).toHaveTextContent(
+      "3",
+    );
+
+    const createButton = screen.queryByText("Create RecommendationRequest");
+    expect(createButton).not.toBeInTheDocument();
+
+    expect(screen.getByText("student1@ucsb.edu")).toBeInTheDocument();
+
     expect(
-      screen.getByText("Index page not yet implemented"),
-    ).toBeInTheDocument();
+      screen.queryByTestId(
+        "RecommendationRequestTable-cell-row-0-col-Delete-button",
+      ),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByTestId(
+        "RecommendationRequestTable-cell-row-0-col-Edit-button",
+      ),
+    ).not.toBeInTheDocument();
+  });
+
+  test("renders empty table when backend unavailable, user only", async () => {
+    setupUserOnly();
+
+    axiosMock.onGet("/api/recommendationrequests/all").timeout();
+
+    const restoreConsole = mockConsole();
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <RecommendationRequestIndexPage />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    await waitFor(() => {
+      expect(axiosMock.history.get.length).toBeGreaterThanOrEqual(1);
+    });
+
+    const errorMessage = console.error.mock.calls[0][0];
+    expect(errorMessage).toMatch(
+      "Error communicating with backend via GET on /api/recommendationrequests/all",
+    );
+    restoreConsole();
+  });
+
+  test("what happens when you click delete, admin", async () => {
+    setupAdminUser();
+
+    axiosMock
+      .onGet("/api/recommendationrequests/all")
+      .reply(200, recommendationRequestFixtures.threeRecommendationRequests);
+    axiosMock
+      .onDelete("/api/recommendationrequest")
+      .reply(200, "RecommendationRequest with id 1 was deleted");
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <RecommendationRequestIndexPage />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    await waitFor(() => {
+      expect(
+        screen.getByTestId(`${testId}-cell-row-0-col-id`),
+      ).toBeInTheDocument();
+    });
+
+    expect(screen.getByTestId(`${testId}-cell-row-0-col-id`)).toHaveTextContent(
+      "1",
+    );
+
+    const deleteButton = await screen.findByTestId(
+      `${testId}-cell-row-0-col-Delete-button`,
+    );
+    expect(deleteButton).toBeInTheDocument();
+
+    fireEvent.click(deleteButton);
+
+    await waitFor(() => {
+      expect(mockToast).toBeCalledWith(
+        "RecommendationRequest deleted successfully",
+      );
+    });
+
+    await waitFor(() => {
+      expect(axiosMock.history.delete.length).toBe(1);
+    });
+    expect(axiosMock.history.delete[0].url).toBe("/api/recommendationrequest");
+    expect(axiosMock.history.delete[0].params).toEqual({ id: 1 });
   });
 });


### PR DESCRIPTION
Fixes #27 
Merge after #124 

This pull request implements the full CRUD UI for RecommendationRequest pages, including create, edit, and index functionality, and provides comprehensive Storybook stories and tests for these pages. The most important changes are grouped below.

### Feature Implementation

* Implemented `RecommendationRequestCreatePage`, `RecommendationRequestEditPage`, and `RecommendationRequestIndexPage` with forms, backend integration, navigation, and toast notifications for user feedback. [[1]](diffhunk://#diff-d79a84296b1dfe4c0969ece78229c6841c595009e474f3fc6d70759859bfd4b3R2-R48) [[2]](diffhunk://#diff-e3b17ed8e188ca838510cb0c7a858dc91f57b06c48ad3893c5d51ee22d991189R2-R77) [[3]](diffhunk://#diff-1a2d2b56561b82a93d69e1668318e85f67be49435f3ce5d4ac2b97225dad7740R1-R45)

### Storybook and Testing

* Added Storybook stories for all three pages, including scenarios for empty and populated data, and admin/ordinary user roles. [[1]](diffhunk://#diff-22ebdaf4a0eae3019dd2458f067041150f7ab6eba64a623730533fb258e9e72aR1-R32) [[2]](diffhunk://#diff-6bbe5c4ca5a3ae474bf92d45d3930c0f0cc25e0aaf443b933b3a14c70f61cd02R1-R39) [[3]](diffhunk://#diff-d69302eeb9858718010e712abf72034b1f8536c742c9651e6afe520300d938c9R1-R83)
* Created and updated tests for create and edit pages, including form submission, backend request mocking, navigation, and toast verification. [[1]](diffhunk://#diff-a5623e71c6ebb0ce216ff8271baf69997c3aeae544f0bcd14107f8cd2731e424L1-R37) [[2]](diffhunk://#diff-a5623e71c6ebb0ce216ff8271baf69997c3aeae544f0bcd14107f8cd2731e424L24-R78) [[3]](diffhunk://#diff-a5623e71c6ebb0ce216ff8271baf69997c3aeae544f0bcd14107f8cd2731e424L38-R124) [[4]](diffhunk://#diff-840058c8bf891db96e7e3388969940a1a3864dbdfae4199815b79beab9c4df7aL1-R82) [[5]](diffhunk://#diff-840058c8bf891db96e7e3388969940a1a3864dbdfae4199815b79beab9c4df7aL24-R122)

These changes complete the UI and test coverage for managing RecommendationRequests in the frontend.

# Acceptance Criteria:

- [ ] When the user navigates to `/recommendationrequest/edit/:id` where `:id` 
      is the `id` field of a valid record in the table, the page will be populated
      with data from that row of the database, and will be able to edit fields
      from that database record.

- [ ] Valid changes made on the page are saved to the database when the user clicks
      the submit button.
- [ ] Changes made on the page are NOT saved when the page contains invalid data; instead,
      appropriate error messages are shown.
- [ ] Changes made on the page are NOT saved when the user clicks the cancel button,
      and the user is routed back to the previous page they were on (like the "back button").     
