### PR TITLE
as - completed end to end testing on Recommendation Request

### DIFF
--- a/frontend/src/main/components/RecommendationRequest/RecommendationRequestTable.jsx
+++ b/frontend/src/main/components/RecommendationRequest/RecommendationRequestTable.jsx
@@ -24,7 +24,7 @@ export default function RecommendationRequestTable({
   const deleteMutation = useBackendMutation(
     cellToAxiosParamsDelete,
     { onSuccess: onDeleteSuccess },
-    ["/api/recommendationrequest/all"],
+    ["/api/recommendationrequests/all"],
   );
   // Stryker restore all
 

--- a/frontend/src/main/components/RecommendationRequest/RecommendationRequestTable.jsx
+++ b/frontend/src/main/components/RecommendationRequest/RecommendationRequestTable.jsx
@@ -24,7 +24,7 @@ export default function RecommendationRequestTable({
   const deleteMutation = useBackendMutation(
     cellToAxiosParamsDelete,
     { onSuccess: onDeleteSuccess },
-    ["/api/recommendationrequests/all"],
+    ["/api/recommendationrequest/all"],
   );
   // Stryker restore all
 

--- a/src/test/java/edu/ucsb/cs156/example/web/RecommendationRequestWebIT.java
+++ b/src/test/java/edu/ucsb/cs156/example/web/RecommendationRequestWebIT.java
@@ -1,0 +1,61 @@
+package edu.ucsb.cs156.example.web;
+
+import static com.microsoft.playwright.assertions.PlaywrightAssertions.assertThat;
+
+import edu.ucsb.cs156.example.WebTestCase;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.annotation.DirtiesContext.ClassMode;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+@ExtendWith(SpringExtension.class)
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.DEFINED_PORT)
+@ActiveProfiles("integration")
+@DirtiesContext(classMode = ClassMode.BEFORE_EACH_TEST_METHOD)
+public class RecommendationRequestWebIT extends WebTestCase {
+
+  @Test
+  public void admin_user_can_create_edit_delete_recommendation_request() throws Exception {
+    setupUser(true);
+
+    page.getByText("RecommendationRequest").click();
+
+    page.getByText("Create RecommendationRequest").click();
+    assertThat(page.getByText("Create New RecommendationRequest")).isVisible();
+
+    page.getByTestId("RecommendationRequestForm-requesterEmail").fill("student@ucsb.edu");
+    page.getByTestId("RecommendationRequestForm-professorEmail").fill("prof@ucsb.edu");
+    page.getByTestId("RecommendationRequestForm-explanation").fill("Need rec for grad school");
+    page.getByTestId("RecommendationRequestForm-dateRequested").fill("2024-01-15T00:00");
+    page.getByTestId("RecommendationRequestForm-dateNeeded").fill("2024-03-01T00:00");
+    page.getByTestId("RecommendationRequestForm-submit").click();
+
+    assertThat(page.getByTestId("RecommendationRequestTable-cell-row-0-col-requesterEmail"))
+        .hasText("student@ucsb.edu");
+
+    page.getByTestId("RecommendationRequestTable-cell-row-0-col-Edit-button").click();
+    assertThat(page.getByText("Edit RecommendationRequest")).isVisible();
+    page.getByTestId("RecommendationRequestForm-explanation").fill("Updated explanation");
+    page.getByTestId("RecommendationRequestForm-submit").click();
+
+    assertThat(page.getByTestId("RecommendationRequestTable-cell-row-0-col-explanation"))
+        .hasText("Updated explanation");
+
+    page.getByTestId("RecommendationRequestTable-cell-row-0-col-Delete-button").click();
+  }
+
+  @Test
+  public void regular_user_cannot_create_recommendation_request() throws Exception {
+    setupUser(false);
+
+    page.getByText("RecommendationRequest").click();
+
+    assertThat(page.getByText("Create RecommendationRequest")).not().isVisible();
+    assertThat(page.getByTestId("RecommendationRequestTable-cell-row-0-col-requesterEmail"))
+        .not()
+        .isVisible();
+  }
+}


### PR DESCRIPTION
Fixes #128 

This pull request adds a new Web test class to verify the web UI functionality for `RecommendationRequest`. The tests cover both admin and regular user scenarios, ensuring that only admins can create, edit, and delete recommendation requests, while regular users have restricted access.

**New Web Tests for RecommendationRequest UI:**

* Added `RecommendationRequestWebIT` Web test class to test the web UI for `RecommendationRequest`, verifying create, edit, and delete operations for admin users, and access restrictions for regular users.